### PR TITLE
Added error checking in install_libzmq.sh

### DIFF
--- a/install_libzmq.sh
+++ b/install_libzmq.sh
@@ -15,20 +15,26 @@ else
 fi
 echo
 
+echo "# checking for root user"
+if [ "$EUID" -ne 0 ];
+	then echo "Please run the command as 'sudo $0 $@'"
+	exit
+fi
+
 echo "# adding additional repo tools"
-sudo apt-get install -y software-properties-common python-software-properties
+apt-get install -y software-properties-common python-software-properties || echo "# Installation of software-properties-common and pyton-software-properties installation failed!"
 echo
 
 echo "# adding modern zeromq repository"
-sudo add-apt-repository -y ppa:chris-lea/zeromq
+add-apt-repository -y ppa:chris-lea/zeromq || echo "# Adding modern zeromq repository failed. First fix adding the command 'sudo add-apt-repository -y ppa:chris-lea/zeromq '"
 echo
 
 echo "# updating repositories"
-sudo apt-get update
+apt-get update || echo "# apt-get update failed!"
 echo
 
 echo "# installing modern zeromq packages"
-sudo apt-get install -y libzmq3-dev libzmq3 python-zmq
+apt-get install -y libzmq3-dev libzmq3 python-zmq || echo "# Installation of libzmq3-dev libzmq3 python-zmq failed!"
 echo
 
 echo "# done"


### PR DESCRIPTION
- Provided more information to a user for failures in the 'apt' related commands. 
- Added root check to the script since all 'apt' commands are run as root.
